### PR TITLE
og ping

### DIFF
--- a/commands/General/Chat Bot Info/ping.js
+++ b/commands/General/Chat Bot Info/ping.js
@@ -9,6 +9,6 @@ module.exports = class extends Command {
     }
 
     async run(message) {
-        return message.send(`Pong! \`${Math.floor(this.client.ws.ping)} ms\``);
+        return message.send(`pOng! \`${Math.floor(this.client.ws.ping)} ms\``);
     }
 };


### PR DESCRIPTION
This is an urgent issue. The ping command dose not respond with the original message pre-rewrite scrambler did. The original response to the ping command used a lower case 'p' and an upper case 'o', adding an element of humor and casualness to an otherwise mundane command, thus the entire bot. This is only fitting as this bot was developed by two high school students not really qualified to program anything, as apparent from the code. 

I may or may not have too much free time atm