### PR TITLE
Fix typo for skewb

### DIFF
--- a/src/util/scrambles.json
+++ b/src/util/scrambles.json
@@ -17,7 +17,7 @@
     },
     "skewb" : {
         "max": 12,
-        "fullName": "skweb"
+        "fullName": "skewb"
     },
     "sq1" : {
         "max": 12,


### PR DESCRIPTION
Skewb was spelled as skweb